### PR TITLE
Remove contact header menu option

### DIFF
--- a/templates/header.html
+++ b/templates/header.html
@@ -67,7 +67,6 @@
                 >Home</a
               >
             </li>
-            
             <li class="nav-item">
               <a
                 class="nav-link px-lg-3 py-3 py-lg-4"
@@ -78,12 +77,6 @@
               <a
                 class="nav-link px-lg-3 py-3 py-lg-4"
                 >About</a
-              >
-            </li>
-            <li class="nav-item">
-              <a
-                class="nav-link px-lg-3 py-3 py-lg-4"
-                >Contact</a
               >
             </li>
           </ul>


### PR DESCRIPTION
With these changes we removed the contact header menu option. It felt
simpler to add the contact form from within the about page.
