### PR TITLE
Add DS store files to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,9 @@ __pycache__/
 # C extensions
 *.so
 
+# DS store files 
+**/.DS_Store
+
 # Distribution / packaging
 .Python
 build/


### PR DESCRIPTION
With these changes we added the macOS DS-store files to the gitignore.
This will prevent them from being committed to the repository.
