### PR TITLE
Add link to the home section of the menu

### DIFF
--- a/templates/header.html
+++ b/templates/header.html
@@ -64,6 +64,7 @@
             <li class="nav-item">
               <a
                 class="nav-link px-lg-3 py-3 py-lg-4"
+                href="{{ url_for('get_all_posts') }}"
                 >Home</a
               >
             </li>


### PR DESCRIPTION
Presently yhe "home" header menu doesn't have a link to the home section.
In these changes we added the link to the headers.html to add the
functionality to get back to the home page once we have navigated away
from it.
